### PR TITLE
remove deploy step from output processor

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -5,5 +5,4 @@ ignores: [
   "rimraf",
   "ts-jest",
 ]
-skip-missing: true
 quiet: true

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           buildInputs = [ pkgs.nodejs_20 ];
           nativeBuildInputs = [ pkgs.installShellFiles ];
           src = self;
-          npmDepsHash = "sha256-rBz/oLvfyz57/xvjYC31WSQh2/27oXLgSL7vTqL5fqE=";
+          npmDepsHash = "sha256-QVKF0ws69BX3UAMoYVXeq7laEucgvA0Om1aRnJZhmZc=";
 
           postInstall = ''
             installShellCompletion --cmd mserve \

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "yargs": "^17.7.2"
+        "chalk": "^5",
+        "yargs": "^17"
       },
       "bin": {
         "mserve": "dist/cli/main.js"
       },
       "devDependencies": {
         "@eslint/js": "^9",
-        "@tsconfig/node20": "^20.1.4",
+        "@tsconfig/node20": "^20",
         "@types/eslint__js": "^8",
         "@types/jest": "^29",
         "@types/node": "^22",
-        "@types/yargs": "^17.0.33",
+        "@types/yargs": "^17",
         "depcheck": "^1",
         "eslint": "^9",
         "eslint-config-prettier": "^9",
@@ -33,6 +33,9 @@
         "ts-jest": "^29",
         "typescript": "^5",
         "typescript-eslint": "^8"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
         "@mml-io/esbuild-plugin-mml": "^0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9",
+        "@mml-io/esbuild-plugin-mml": "^0.1",
         "@tsconfig/node20": "^20",
         "@types/eslint__js": "^8",
         "@types/jest": "^29",
@@ -36,10 +37,6 @@
       },
       "engines": {
         "node": ">=16"
-      },
-      "peerDependencies": {
-        "@mml-io/esbuild-plugin-mml": "^0.1",
-        "esbuild": "^0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -538,6 +535,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -554,6 +552,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -570,6 +569,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -586,6 +586,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -602,6 +603,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -618,6 +620,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -634,6 +637,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -650,6 +654,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -666,6 +671,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -682,6 +688,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -698,6 +705,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -714,6 +722,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -730,6 +739,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -746,6 +756,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -762,6 +773,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -778,6 +790,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -794,6 +807,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -810,6 +824,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -826,6 +841,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -842,6 +858,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -858,6 +875,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -874,6 +892,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -890,6 +909,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -906,6 +926,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1968,7 +1989,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mml-io/esbuild-plugin-mml/-/esbuild-plugin-mml-0.1.0.tgz",
       "integrity": "sha512-tfFG1WjfGV4mxerEq8Do3hb/1YrngcYor5sJz9/QvhdLnDyiAvYsvtFdtsvibDwb7UQSXHMUd/pEC7h+M4x3xA==",
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "esbuild": "^0"
       }
@@ -3665,6 +3686,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
       "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+      "dev": true,
       "hasInstallScript": true,
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -6,18 +6,22 @@
   "license": "MIT",
   "sideEffects": false,
   "type": "module",
+  "engineStrict": true,
+  "engines": {
+    "node": ">=16"
+  },
   "bin": {
     "mserve": "dist/cli/main.js"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
+      "require": "./dist/index.js",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "keywords": [
     "mml",
@@ -46,11 +50,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9",
-    "@tsconfig/node20": "^20.1.4",
+    "@mml-io/esbuild-plugin-mml": "^0.1",
+    "@tsconfig/node20": "^20",
     "@types/eslint__js": "^8",
     "@types/jest": "^29",
     "@types/node": "^22",
-    "@types/yargs": "^17.0.33",
+    "@types/yargs": "^17",
     "depcheck": "^1",
     "eslint": "^9",
     "eslint-config-prettier": "^9",
@@ -64,11 +69,7 @@
     "typescript-eslint": "^8"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
-    "yargs": "^17.7.2"
-  },
-  "peerDependencies": {
-    "@mml-io/esbuild-plugin-mml": "^0.1",
-    "esbuild": "^0"
+    "chalk": "^5",
+    "yargs": "^17"
   }
 }

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -159,7 +159,7 @@ export async function deployFileOrDirectory({
   const parsedURL = parseURL(origin);
 
   if (parsedURL === null) {
-    console.log(chalk.red.bold(`Unable to parse MServer origin: "${origin}"`));
+    console.log(chalk.red.bold(`Unable to parse MServe origin: "${origin}"`));
     process.exit(-1);
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import yargs from "yargs";
 import { deployFileOrDirectory } from "./deploy.js";
 

--- a/src/lib/output-processor.ts
+++ b/src/lib/output-processor.ts
@@ -3,26 +3,9 @@ import type { OutputProcessorProvider } from "@mml-io/esbuild-plugin-mml";
 import path from "node:path";
 import crypto from "node:crypto";
 
-export interface MServeOutputProcessorOptions {
-  projectId: string;
-  apiKey: string;
-  mserve?: {
-    protocol?: "https" | "http" | (string & {});
-    host: string;
-  };
-  deploy?: boolean;
-}
-
-export function mserveOutputProcessor({
-  projectId,
-}: MServeOutputProcessorOptions): OutputProcessorProvider {
-  interface Deployable {
-    id: string;
-    name: string;
-    importStr: string;
-  }
-  const deployables: Partial<Record<string, Deployable>> = {};
-
+export function mserveOutputProcessor(
+  projectId: string,
+): OutputProcessorProvider {
   return () => ({
     onOutput(inPath: string) {
       const extname = path.extname(inPath);
@@ -38,9 +21,9 @@ export function mserveOutputProcessor({
 
       const importStr = `${projectId}_${id}`;
 
-      deployables[inPath] = { name, id, importStr };
+      const newPath = id + extname;
 
-      return { importStr };
+      return { importStr, path: newPath };
     },
   });
 }

--- a/src/lib/output-processor.ts
+++ b/src/lib/output-processor.ts
@@ -1,15 +1,9 @@
-import type {
-  OutputProcessorProvider,
-  MMLWorldConfig,
-} from "@mml-io/esbuild-plugin-mml";
+import type { OutputProcessorProvider } from "@mml-io/esbuild-plugin-mml";
 
-import fs from "node:fs/promises";
 import path from "node:path";
 import crypto from "node:crypto";
-import type esbuild from "esbuild";
-import { gzip } from "./gzip.js";
 
-export interface MServerOutputProcessorOptions {
+export interface MServeOutputProcessorOptions {
   projectId: string;
   apiKey: string;
   mserve?: {
@@ -21,10 +15,7 @@ export interface MServerOutputProcessorOptions {
 
 export function mserveOutputProcessor({
   projectId,
-  apiKey,
-  deploy = false,
-  mserve = { host: "api.mserve.io" },
-}: MServerOutputProcessorOptions): OutputProcessorProvider {
+}: MServeOutputProcessorOptions): OutputProcessorProvider {
   interface Deployable {
     id: string;
     name: string;
@@ -32,7 +23,7 @@ export function mserveOutputProcessor({
   }
   const deployables: Partial<Record<string, Deployable>> = {};
 
-  return (log: typeof console.log) => ({
+  return () => ({
     onOutput(inPath: string) {
       const extname = path.extname(inPath);
       const dirname = path.dirname(inPath);
@@ -50,148 +41,6 @@ export function mserveOutputProcessor({
       deployables[inPath] = { name, id, importStr };
 
       return { importStr };
-    },
-    async onEnd(outdir: string, result: esbuild.BuildResult) {
-      if (!deploy) {
-        log("skipping deployment");
-        return;
-      }
-
-      const outputs = Object.keys(result.metafile?.outputs ?? {});
-      log("deploying outputs to MServe", { projectId, deployables, outputs });
-
-      interface MMLWorldInstanceRequest {
-        name: string;
-        mmlDocumentsConfiguration: MMLWorldConfig;
-      }
-
-      interface MMLObjectInstanceRequest {
-        name: string;
-        description?: string;
-        enabled?: boolean;
-        parameters?: object;
-        source: {
-          type: "source";
-          source: string;
-        };
-      }
-
-      const objectInstancesUrl = `${mserve.protocol ?? "https"}://${mserve.host}/v1/mml-objects/${projectId}/object-instances`;
-      const worldInstancesUrl = `${mserve.protocol ?? "https"}://${mserve.host}/v1/worlds/${projectId}/web-world-instances`;
-
-      const out = Object.keys(result.metafile?.outputs ?? {}).map(
-        async (output) => {
-          const deployable = deployables[path.relative(outdir, output)];
-          if (!deployable) {
-            return undefined;
-          }
-          const { name, id } = deployable;
-          const source = await fs.readFile(output, {
-            encoding: "utf8",
-          });
-
-          if (output.endsWith(".html")) {
-            const request: MMLObjectInstanceRequest = {
-              name,
-              source: {
-                type: "source",
-                source,
-              },
-            };
-            log("deploying", { deployable });
-            let response = await fetch(objectInstancesUrl + "/" + id, {
-              method: "POST",
-              body: await gzip(JSON.stringify({ ...request, parameters: {} })),
-              headers: {
-                authorization: `Bearer ${apiKey}`,
-                "content-type": "application/json",
-                "content-encoding": "gzip",
-              },
-            });
-
-            if (response.status === 404) {
-              log("object instance does not exist, creating...");
-              response = await fetch(objectInstancesUrl, {
-                method: "POST",
-                body: await gzip(JSON.stringify({ ...request, id })),
-                headers: {
-                  authorization: `Bearer ${apiKey}`,
-                  "content-type": "application/json",
-                  "content-encoding": "gzip",
-                },
-              });
-            }
-            if (response.status !== 200) {
-              const { status } = response;
-              const message = await response.text();
-              log("failed to deploy object instance", {
-                deployable,
-                status,
-                message,
-              });
-              return {
-                text: "",
-                detail: {
-                  status: response.status,
-                  message: await response.text(),
-                },
-              };
-            }
-          } else if (output.endsWith(".json")) {
-            const request: MMLWorldInstanceRequest = {
-              name,
-              mmlDocumentsConfiguration: JSON.parse(source) as unknown,
-            };
-            log("deploying", { deployable });
-            let response = await fetch(worldInstancesUrl + "/" + id, {
-              method: "POST",
-              body: await gzip(JSON.stringify(request)),
-              headers: {
-                authorization: `Bearer ${apiKey}`,
-                "content-type": "application/json",
-                "content-encoding": "gzip",
-              },
-            });
-
-            if (response.status === 404) {
-              log("world instance does not exist, creating...");
-              response = await fetch(worldInstancesUrl, {
-                method: "POST",
-                body: await gzip(JSON.stringify({ ...request, id })),
-                headers: {
-                  authorization: `Bearer ${apiKey}`,
-                  "content-type": "application/json",
-                  "content-encoding": "gzip",
-                },
-              });
-            }
-            if (response.status !== 200) {
-              const { status } = response;
-              const message = await response.text();
-              log("failed to deploy world instance", {
-                deployable,
-                status,
-                message,
-              });
-              return {
-                text: "",
-                detail: {
-                  status: response.status,
-                  message: await response.text(),
-                },
-              };
-            }
-          }
-          log(`deployed output ${name} to MServe`, deployable);
-        },
-      );
-      return Promise.all(out).then((results) => {
-        const errors = results.reduce<esbuild.PartialMessage[]>(
-          (errors, error) => (error ? errors.concat(error) : errors),
-          [],
-        );
-        return { errors };
-      });
     },
   });
 }


### PR DESCRIPTION
This PR removes the deployment process from on the onEnd hook to give the user a change to inspect the output before deploying.

This PR also ensures the output files are renamed to be compatible with the CLI deployment process.

---

**What kind of changes does your PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe its impact and migration path for existing applications:

Deployment process has been removed, however no one is relying on this yet so we don't need to worry

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
